### PR TITLE
Responding to feedback

### DIFF
--- a/src/DummyFileBasedCms.Web/FlatFileCmsGitOptions.cs
+++ b/src/DummyFileBasedCms.Web/FlatFileCmsGitOptions.cs
@@ -1,12 +1,19 @@
-﻿namespace DummyFileBasedCms.Web
+﻿using System.Collections.Generic;
+
+namespace DummyFileBasedCms.Web
 {
     public class FlatFileCmsGitOptions
     {
-        public string FilePath { get; set; }
-        public string RepositoryUrl { get; set; }
-        public string Branch { get; set; }
-        public string PublicKey { get; set; }
-        public string PrivateKey { get; set; }
-        public string Passphrase { get; set; }
+        public List<Directory> Directories { get; set; } = new List<Directory>();
+
+        public class Directory
+        {
+            public string FilePath { get; set; }
+            public string RepositoryUrl { get; set; }
+            public string Branch { get; set; }
+            public string PublicKey { get; set; }
+            public string PrivateKey { get; set; }
+            public string Passphrase { get; set; }
+        }
     }
 }

--- a/src/DummyFileBasedCms.Web/appsettings.json
+++ b/src/DummyFileBasedCms.Web/appsettings.json
@@ -6,10 +6,21 @@
   },
   "AllowedHosts": "*",
   "FlatFileCmsGit": {
-    "FilePath": "C:/CMSContent/Pages",
-    "RepositoryUrl":"",
-    "PublicKey": "",
-    "PrivateKey": "",
-    "Passphrase": "" 
+    "directories": [
+      {
+        "FilePath": "C:\\git\\sparkeh9\\A",
+        "RepositoryUrl": "",
+        "PublicKey": "",
+        "PrivateKey": "",
+        "Passphrase": ""
+      },
+      {
+        "FilePath": "C:\\git\\sparkeh9\\B",
+        "RepositoryUrl": "",
+        "PublicKey": "",
+        "PrivateKey": "",
+        "Passphrase": ""
+      }
+    ]
   } 
 }


### PR DESCRIPTION
Responding to a few of your comments with some additional suggestiongs...

> When I set the folder structure in the configuration, it didn't work unless I had the pages in a "Pages" folder, without including that in the config

This is a setting. It's global (all file providers), so I guess you'll have to think about if you want the default setting or not. See the startup code. 

>When I included the additional physical file provider, the ones included under the app root stopped resolving. I tried adding a second physical file provider (so we're up to three now including the app root one) and only the first one added seems to allow pages to be resolved

I can't reproduce this. Based on my updated code, it works on my machine 😁


> Inside the services.Configure<RazorViewEngineOptions> block, options.FileProviders is an empty collection, it seems the built-in provider is added some time after this stage, because when I inject IRazorViewEngineFileProviderAccessor, I see all the providers which I added, with the built-in one at the last index. Only the first in the collection is looked at and serves pages

Yeah this was bad advice from me to put the code in this order. Configure callbacks are run in order, so putting your registration before MVC means it runs before MVC. I updated this code to the example I would typically show.